### PR TITLE
Fixed rmap

### DIFF
--- a/org.palladiosimulator.probeframework.buckminster/probeframework.rmap
+++ b/org.palladiosimulator.probeframework.buckminster/probeframework.rmap
@@ -1,24 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rm:rmap xmlns:bc="http://www.eclipse.org/buckminster/Common-1.0" xmlns:rm="http://www.eclipse.org/buckminster/RMap-1.0">
 
-  <rm:property key="resolveFrom" value="release"/>
-  
-  <rm:locator pattern="^org\.palladiosimulator\.probeframework.*" searchPathRef="ProbeFramework" failOnError="true"/>
+	<rm:property key="resolveFrom" value="release"/>
 
-  <rm:redirect pattern=".*" href="https://anonymous:anonymous@svnserver.informatik.kit.edu/i43/svn/code/EDP2/trunk/org.palladiosimulator.edp2.buckminster/edp2.rmap"/>
+	<rm:locator pattern="^org\.palladiosimulator\.probeframework.*" searchPathRef="ProbeFramework" failOnError="true"/>
+	<rm:locator searchPathRef="edp2svn" failOnError="true" pattern="^org\.palladiosimulator\.edp2.*" />
+	<rm:locator pattern="^org\.palladiosimulator\.measurementframework.*" searchPathRef="measurementframework" failOnError="true"/>
+	<rm:locator pattern="^org\.palladiosimulator\.metricspec.*" searchPathRef="metricspec" failOnError="true"/>
+	<rm:locator pattern="^de\.uka\.ipd\.sdq\.[dialogs|errorhandling|identifier|probfuction|statistics|stoex|units].*" searchPathRef="commons" failOnError="true" />
+	<rm:locator pattern="^org\.palladiosimulator\.commons.*" searchPathRef="commons" failOnError="true" />
+	<rm:redirect pattern=".*" href="https://raw.githubusercontent.com/PalladioSimulator/Palladio-ThirdParty-Library/master/org.palladiosimulator.thirdpartywrapper.buckminster/thirdpartywrapper.rmap" />
 
-  <rm:searchPath name="ProbeFramework">
-    <rm:provider resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
-      <rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/probeframework/nightly/"/>
-    </rm:provider>
-    <rm:provider resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
-      <rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/probeframework/releases/latest/"/>
-    </rm:provider>
-    <rm:provider componentTypes="eclipse.feature,osgi.bundle" readerType="svn">
-      <rm:uri format="https://anonymous:anonymous@svnserver.informatik.kit.edu/i43/svn/code/ProbeFramework/trunk/{0}">
-        <bc:propertyRef key="buckminster.component"/>
-      </rm:uri>
-    </rm:provider>
-  </rm:searchPath>
-  
+	<rm:searchPath name="commons">
+		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=nightly)" readerType="p2" source="false" mutable="false">
+			<rm:uri format="https://sdqweb.ipd.kit.edu/eclipse/commons/nightly/"/>
+		</rm:provider>
+		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=release)" readerType="p2" source="false" mutable="false">
+			<rm:uri format="https://sdqweb.ipd.kit.edu/eclipse/commons/releases/latest/"/>
+		</rm:provider>
+	</rm:searchPath>
+
+	<rm:searchPath name="measurementframework">
+		<rm:provider resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/measurementframework/nightly/"/>
+		</rm:provider>
+		<rm:provider resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/measurementframework/releases/latest/"/>
+		</rm:provider>
+	</rm:searchPath>
+
+	<rm:searchPath name="metricspec">
+		<rm:provider resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="https://sdqweb.ipd.kit.edu/eclipse/metricspec/nightly/"/>
+		</rm:provider>
+		<rm:provider resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="https://sdqweb.ipd.kit.edu/eclipse/metricspec/releases/latest/"/>
+		</rm:provider>
+	</rm:searchPath>
+
+	<rm:searchPath name="edp2svn">
+		<rm:provider resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/edp2/nightly/"/>
+		</rm:provider>
+		<rm:provider resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/edp2/releases/latest/"/>
+		</rm:provider>
+	</rm:searchPath>
+
+	<rm:searchPath name="ProbeFramework">
+		<rm:provider resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/probeframework/nightly/"/>
+		</rm:provider>
+		<rm:provider resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/probeframework/releases/latest/"/>
+		</rm:provider>
+		<rm:provider componentTypes="eclipse.feature,osgi.bundle" readerType="git" source="true">
+			<rm:uri format="{0}/GIT,{1}">
+				<bc:propertyRef key="workspace.root" />
+				<bc:propertyRef key="buckminster.component" />
+			</rm:uri>
+			<rm:property key="git.remote.uri" value="https://github.com/PalladioSimulator/Palladio-QuAL-ProbeFramework"/>
+			<rm:property key="git.auto.fetch" value="true"/>
+		</rm:provider>
+	</rm:searchPath>
+
 </rm:rmap>


### PR DESCRIPTION
The rmap of ProbeFramework was completely broken after several migrations to Github. This fixed the rmap.