### PR TITLE
Support already registering calculator factories

### DIFF
--- a/bundles/org.palladiosimulator.probeframework/src/org/palladiosimulator/probeframework/ProbeFrameworkContext.java
+++ b/bundles/org.palladiosimulator.probeframework/src/org/palladiosimulator/probeframework/ProbeFrameworkContext.java
@@ -43,10 +43,16 @@ public class ProbeFrameworkContext {
         if (calculatorFactory == null) {
             throw new IllegalArgumentException("A valid calculator factory is required.");
         }
-        var decorator = new RegisterCalculatorFactoryDecorator(calculatorFactory); 
-        this.calculatorFactory = ICalculatorFactoryLegacyAdapter.createDelegatingAdapter(decorator);
-        this.calculatorRegistry = decorator;
-        cleanupTasks.add(decorator::finish);
+        // Do not decorate an already registering factory
+        if (calculatorFactory instanceof IObservableCalculatorRegistry) {
+            this.calculatorRegistry = (IObservableCalculatorRegistry) calculatorFactory;
+            this.calculatorFactory = ICalculatorFactoryLegacyAdapter.createDelegatingAdapter(calculatorFactory);
+        } else {
+            var decorator = new RegisterCalculatorFactoryDecorator(calculatorFactory);
+            this.calculatorRegistry = decorator;
+            this.calculatorFactory = ICalculatorFactoryLegacyAdapter.createDelegatingAdapter(decorator);
+            cleanupTasks.add(decorator::finish);
+        }
     }
 
     /**

--- a/tests/org.palladiosimulator.probeframework.tests/META-INF/MANIFEST.MF
+++ b/tests/org.palladiosimulator.probeframework.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: ProbeFramework Test Plug-in
 Bundle-SymbolicName: org.palladiosimulator.probeframework.tests
 Bundle-Version: 4.3.0.qualifier
+Fragment-Host: org.palladiosimulator.probeframework
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0",
  org.palladiosimulator.probeframework;bundle-version="2.0.1",
@@ -12,7 +13,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.palladiosimulator.metricspec;bundle-version="1.0.1",
  org.palladiosimulator.measurementframework;bundle-version="1.0.1",
  org.palladiosimulator.metricspec.resources;bundle-version="1.0.0",
- org.palladiosimulator.edp2
+ org.palladiosimulator.edp2,
+ org.junit,
+ org.junit.jupiter.api
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: palladiosimulator.org

--- a/tests/org.palladiosimulator.probeframework.tests/src/org/palladiosimulator/probeframework/test/ProbeFrameworkContextTest.java
+++ b/tests/org.palladiosimulator.probeframework.tests/src/org/palladiosimulator/probeframework/test/ProbeFrameworkContextTest.java
@@ -1,0 +1,104 @@
+package org.palladiosimulator.probeframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringPoint;
+import org.palladiosimulator.edp2.models.measuringpoint.MeasuringpointFactory;
+import org.palladiosimulator.edp2.models.measuringpoint.ResourceURIMeasuringPoint;
+import org.palladiosimulator.metricspec.MetricDescription;
+import org.palladiosimulator.metricspec.constants.MetricDescriptionConstants;
+import org.palladiosimulator.probeframework.ProbeFrameworkContext;
+import org.palladiosimulator.probeframework.calculator.Calculator;
+import org.palladiosimulator.probeframework.calculator.CalculatorProbeSet;
+import org.palladiosimulator.probeframework.calculator.CalculatorRegistryListener;
+import org.palladiosimulator.probeframework.calculator.DefaultCalculatorProbeSets;
+import org.palladiosimulator.probeframework.calculator.IGenericCalculatorFactory;
+import org.palladiosimulator.probeframework.calculator.IObservableCalculatorRegistry;
+import org.palladiosimulator.probeframework.calculator.internal.IdentityCalculator;
+import org.palladiosimulator.probeframework.probes.Probe;
+
+class ProbeFrameworkContextTest {
+    Probe mockProbe;
+    ResourceURIMeasuringPoint mockMeasuringPoint;
+    Calculator mockCalculator;
+    
+    @BeforeEach
+    void setup() {
+        mockProbe = new Probe(MetricDescriptionConstants.RESOURCE_DEMAND_METRIC) {};
+        mockMeasuringPoint = MeasuringpointFactory.eINSTANCE.createResourceURIMeasuringPoint();
+        mockMeasuringPoint.setResourceURI("dummy.mock");
+        mockMeasuringPoint.setMeasuringPoint("dummy.mock");
+        mockCalculator = new IdentityCalculator(mockMeasuringPoint, mockProbe);
+    }
+
+    @Test
+    void testProbeFrameworkDecoration() {
+        var factoryMock = new IGenericCalculatorFactory() {
+            @Override
+            public Calculator buildCalculator(MetricDescription metric, MeasuringPoint measuringPoint,
+                    CalculatorProbeSet probeConfiguration) {
+                return mockCalculator;
+            }
+        };
+        var underTest = new ProbeFrameworkContext(factoryMock);
+        assertEquals(mockCalculator, underTest.getGenericCalculatorFactory()
+            .buildCalculator(MetricDescriptionConstants.RESOURCE_DEMAND_METRIC, mockMeasuringPoint,
+                    DefaultCalculatorProbeSets.createSingularProbeConfiguration(mockProbe)));
+        assertEquals(mockCalculator, underTest.getCalculatorRegistry()
+            .getCalculatorByMeasuringPointAndMetricDescription(mockMeasuringPoint,
+                    MetricDescriptionConstants.RESOURCE_DEMAND_METRIC));
+        
+        assertNotEquals(factoryMock, underTest.getCalculatorRegistry());
+    }
+    
+    public static class MockFactory implements IGenericCalculatorFactory, IObservableCalculatorRegistry {
+        @Override
+        public Calculator buildCalculator(MetricDescription metric, MeasuringPoint measuringPoint,
+                CalculatorProbeSet probeConfiguration) {
+            return null;
+        }
+
+        @Override
+        public Collection<Calculator> getRegisteredCalculators() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Collection<Calculator> getCalculatorsForMeasuringPoint(MeasuringPoint measuringPoint) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Calculator getCalculatorByMeasuringPointAndMetricDescription(MeasuringPoint mp,
+                MetricDescription metric) {
+            return null;
+        }
+
+        @Override
+        public void addObserver(CalculatorRegistryListener observer) {
+        }
+
+        @Override
+        public void removeObserver(CalculatorRegistryListener observer) {
+        }
+
+        @Override
+        public Collection<CalculatorRegistryListener> getObservers() {
+            return null;
+        }
+        
+    }
+    @Test
+    void testProbeFrameworkNonDecoration() {
+        var factoryMock = new MockFactory();
+        var underTest = new ProbeFrameworkContext(factoryMock);
+        assertEquals(factoryMock, underTest.getCalculatorRegistry());
+    }
+
+}


### PR DESCRIPTION
The ProbeFrameworkContext is created with a GenericCalculatorFactory instance. To cache already created calculators it decorates the factory with an IObservableCalculatorRegistry implementation (Legacy Behavior). This should not be done if the calculator factory already provides the registration functionality (in case of current SimuLizar changes).